### PR TITLE
Make file persistence optional

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -192,8 +192,9 @@ module.exports = {
       /**
        * Sync the files and persist them to the cache
        * @method reconcile
+       * @param persist
        */
-      reconcile: function () {
+      reconcile: function ( persist ) {
         removeNotFoundFiles();
 
         var entries = normalizedEntries;
@@ -222,7 +223,9 @@ module.exports = {
           }
         } );
 
-        cache.save( true );
+        if ( persist !== false ) {
+          cache.save( true );
+        }
       }
     };
   }

--- a/test/specs/cache.js
+++ b/test/specs/cache.js
@@ -115,6 +115,30 @@ describe( 'file-entry-cache', function () {
     expect( fs.existsSync( '../fixtures/.eslintcache' ) ).to.be.false;
   } );
 
+  it( 'should allow to reconcile the cache without persisting to a file', function () {
+    cache = fileEntryCache.createFromFile( '../fixtures/.eslintcache' );
+    var fs = require( 'fs' );
+    var file = path.resolve( __dirname, '../fixtures/f4.txt' );
+    var files = expand( path.resolve( __dirname, '../fixtures/*.txt' ) );
+    var oFiles = cache.getUpdatedFiles( files );
+
+    cache.reconcile( false );
+
+    expect( fs.existsSync( '../fixtures/.eslintcache' ) ).to.be.false;
+
+    expect( cache.hasFileChanged( file ) ).to.be.false;
+
+    // attempt to do a modification
+    write( file, 'some other content' );
+
+    expect( cache.hasFileChanged( file ) ).to.be.true;
+
+    cache.reconcile( false );
+
+    expect( cache.hasFileChanged( file ) ).to.be.false;
+    expect( fs.existsSync( '../fixtures/.eslintcache' ) ).to.be.false;
+  } );
+
   it( 'should return the array of files passed the first time since there was no cache created', function () {
 
     cache = fileEntryCache.create( 'testCache' );


### PR DESCRIPTION
Currently, file persistence is non-optional. One has to call `reconcile()` in order to fill the cache with initial entries which also saves the cache to disk.

With this change, a `persist` flag can be passed which, if explicitly set to `false`, skips saving the cache.

This change is needed in order to implement in-memory caching as suggested in https://github.com/eslint/eslint/issues/10781.