### PR TITLE
Delete previous mtime when checksum is used and vice versa

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -234,6 +234,8 @@ module.exports = {
         var contentBuffer = fs.readFileSync(cacheEntry.key);
         var hash = this.getHash(contentBuffer);
         var meta = Object.assign(cacheEntry.meta, { hash: hash });
+        delete meta.size;
+        delete meta.mtime;
         return meta;
       },
 
@@ -243,6 +245,7 @@ module.exports = {
           size: stat.size,
           mtime: stat.mtime.getTime(),
         });
+        delete meta.hash;
         return meta;
       },
 


### PR DESCRIPTION
Deletes previous `mtime` and `size` if `useCheckSum = true`, or previous `hash` if `useCheckSum = false`.

Fixes possible problems in cases where the same cache file can be used both with and without `useCheckSum = true`, so `mtime`/`size` and `hash` can become out of sync with the custom data.

Refs https://github.com/eslint/rfcs/pull/63#issuecomment-676463622